### PR TITLE
Stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .cabal-sandbox
 cabal.sandbox.config
 *.sw[a-z]
+.stack-work/

--- a/hdevtools.cabal
+++ b/hdevtools.cabal
@@ -68,7 +68,7 @@ executable hdevtools
                        ghc-paths,
                        syb,
                        network,
-                       process,
+                       process >= 1.2.3.0,
                        time,
                        unix
 

--- a/src/CommandLoop.hs
+++ b/src/CommandLoop.hs
@@ -65,7 +65,7 @@ newConfig cmdExtra = do
     mbCabalConfig <- traverse mkCabalConfig $ ceCabalConfig cmdExtra
     mbStackConfig <- getStackConfig cmdExtra
 
-    return $ Config { configGhcOpts = ceGhcOptions cmdExtra
+    return $ Config { configGhcOpts = "-O0" : ceGhcOptions cmdExtra
                     , configCabal = mbCabalConfig
                     , configStack = mbStackConfig
                     }

--- a/src/Stack.hs
+++ b/src/Stack.hs
@@ -7,6 +7,7 @@ module Stack
 
 import Data.Maybe (listToMaybe)
 import Data.Char (isSpace)
+import Control.Applicative((<$>), (<*>))
 import System.Process
 import System.FilePath
 import System.Directory

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,5 @@
+flags: {}
+packages:
+- '.'
+extra-deps: []
+resolver: nightly-2015-07-02


### PR DESCRIPTION
1. Adding the import for the applicative operators fixes the compilation issue with 7.8.4, and adding the version requirement for `process` ensures that the correct one is installed
2. I did something kinda... dumb? to fix the "unboxed tuple" problem I mentioned in the PR. src/CommandLoop.hs line 68: `"-O0" : ....`. It fixes the issue and I don't notice any problems.

The `test_module_file.sh` script is currently failing:

```
test_module_file.sh

Cabal error: At least the following dependencies are missing:
    network -any
Test FAILED
```

Definitely glad to implement any suggestions :)